### PR TITLE
Debug drawing wasn't enabled for sample 08 now it is.

### DIFF
--- a/FeatureSamples/Core/08_Decals/Decals.cs
+++ b/FeatureSamples/Core/08_Decals/Decals.cs
@@ -69,7 +69,7 @@ namespace Urho.Samples
 					// bones. Note that debug geometry has to be separately requested each frame. Disable depth test so that we can see the
 					// bones properly
 					if (drawDebug)
-						Renderer.DrawDebugGeometry(false);
+						Renderer.DrawDebugGeometry(drawDebug);
 				});
 		}
 


### PR DESCRIPTION
Drawing debug geometry was accidentally disabled.

I will be submitting a pull request to the Urho3D repo to fix this in their C++ samples.